### PR TITLE
 Adding ability to  --fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,21 +24,21 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^2.4.0",
+    "@typescript-eslint/experimental-utils": "^2.26.0",
     "eslint-import-resolver-node": "^0.3.2",
     "eslint-module-utils": "^2.4.1"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": ">= 2.5.0",
+    "@typescript-eslint/parser": ">= 2.26.0",
     "eslint": ">= 6.x"
   },
   "devDependencies": {
     "@types/eslint": "^6.1.2",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.11.5",
-    "@typescript-eslint/eslint-plugin": "^2.5.0",
-    "@typescript-eslint/parser": "^2.5.0",
-    "@typescript-eslint/typescript-estree": "^2.4.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
+    "@typescript-eslint/typescript-estree": "^2.26.0",
     "auto": "^7.12.5",
     "eslint": "^6.5.1",
     "eslint-config-prettier": "^6.4.0",
@@ -47,6 +47,6 @@
     "prettier": "1.18.2",
     "rimraf": "3.0.0",
     "ts-jest": "^24.1.0",
-    "typescript": "^3.6.4"
+    "typescript": "^3.8.1-rc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,21 +24,21 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^2.26.0",
+    "@typescript-eslint/experimental-utils": "^2.27.0",
     "eslint-import-resolver-node": "^0.3.2",
     "eslint-module-utils": "^2.4.1"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": ">= 2.26.0",
+    "@typescript-eslint/parser": ">= 2.27.0",
     "eslint": ">= 6.x"
   },
   "devDependencies": {
     "@types/eslint": "^6.1.2",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.11.5",
-    "@typescript-eslint/eslint-plugin": "^2.26.0",
-    "@typescript-eslint/parser": "^2.26.0",
-    "@typescript-eslint/typescript-estree": "^2.26.0",
+    "@typescript-eslint/eslint-plugin": "^2.27.0",
+    "@typescript-eslint/parser": "^2.27.0",
+    "@typescript-eslint/typescript-estree": "^2.27.0",
     "auto": "^7.12.5",
     "eslint": "^6.5.1",
     "eslint-config-prettier": "^6.4.0",
@@ -47,6 +47,6 @@
     "prettier": "1.18.2",
     "rimraf": "3.0.0",
     "ts-jest": "^24.1.0",
-    "typescript": "^3.8.1-rc"
+    "typescript": "3.8.3"
   }
 }

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -6,7 +6,8 @@ const generateTypeFix = (
   variables: string[],
   source: string,
 ) => {
-  return `${type} type { ${variables.join(',')} } ${source};`;
+  const spacedSource = source ? ` ${source}` : '';
+  return `${type} type { ${variables.join(',')} }${spacedSource};`;
 };
 
 const generateNonTypeFix = (
@@ -14,7 +15,8 @@ const generateNonTypeFix = (
   variables: string[],
   source: string,
 ) => {
-  return `${type} { ${variables.join(',')} } ${source};`;
+  const spacedSource = source ? ` ${source}` : '';
+  return `${type} { ${variables.join(',')} }${spacedSource};`;
 };
 
 export const exportFix = (

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -7,7 +7,7 @@ const generateTypeFix = (
   source: string,
 ) => {
   const spacedSource = source ? ` ${source}` : '';
-  return `${type} type { ${variables.join(',')} }${spacedSource};`;
+  return `${type} type { ${variables.join(',')} }${spacedSource};\n`;
 };
 
 const generateNonTypeFix = (

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -1,0 +1,63 @@
+import { RuleFixer } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
+import { TSESTree } from '@typescript-eslint/typescript-estree';
+
+export const exportFix = (
+  node: TSESTree.ImportDeclaration | TSESTree.ExportNamedDeclaration,
+  typedExports: string[],
+  regularExports: string[],
+  fixer: RuleFixer,
+) => {
+  try {
+    const source = (node as TSESTree.ImportDeclaration).source
+      ? 'from ' + (node as TSESTree.ImportDeclaration).source.raw
+      : '';
+
+    let exportTypes = '';
+    let exportRegulars = '';
+    if (typedExports.length) {
+      exportTypes = 'export type { ';
+      exportTypes += typedExports.join(',');
+      exportTypes += ' } ';
+      exportTypes += source + ';';
+    }
+    if (regularExports.length) {
+      exportRegulars = 'export { ';
+      exportRegulars += regularExports.join(',');
+      exportRegulars += ' } ';
+      exportRegulars += source + ';';
+    }
+
+    return fixer.replaceText(node, exportTypes + exportRegulars);
+  } catch {
+    return;
+  }
+};
+
+export const importFixer = (
+  node: TSESTree.ImportDeclaration | TSESTree.ExportNamedDeclaration,
+  typedImports: string[],
+  regularImports: string[],
+  fixer: RuleFixer,
+) => {
+  try {
+    const source = 'from ' + (node as TSESTree.ImportDeclaration).source.raw;
+    let importTypes = '';
+    let importRegulars = '';
+    if (typedImports.length) {
+      importTypes = 'import type { ';
+      importTypes += typedImports.join(',');
+      importTypes += ' } ';
+      importTypes += source + ';';
+    }
+    if (regularImports.length) {
+      importRegulars = 'import { ';
+      importRegulars += regularImports.join(',');
+      importRegulars += ' } ';
+      importRegulars += source + ';';
+    }
+
+    return fixer.replaceText(node, importTypes + importRegulars);
+  } catch {
+    return;
+  }
+};

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -19,7 +19,7 @@ const generateNonTypeFix = (
   return `${type} { ${variables.join(',')} }${spacedSource};`;
 };
 
-export const exportFix = (
+export const exportFixer = (
   node: TSESTree.ExportNamedDeclaration,
   typedExports: string[],
   regularExports: string[],

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -53,7 +53,7 @@ export const importFixer = (
     const importTypes = typedImports.length
       ? generateTypeFix('import', typedImports, source)
       : '';
-    let importRegulars = regularImports.length
+    const importRegulars = regularImports.length
       ? generateNonTypeFix('import', regularImports, source)
       : '';
     return fixer.replaceText(node, importTypes + importRegulars);

--- a/src/rules/no-explicit-type-exports.ts
+++ b/src/rules/no-explicit-type-exports.ts
@@ -104,14 +104,13 @@ export = {
           context.report({
             node,
             message: errorMessage(typedExports[0]),
-            fix: (fixer: RuleFixer) => {
+            fix: (fixer: RuleFixer) =>
               exportFix(
                 node as TSESTree.ExportNamedDeclaration,
                 typedExports,
                 regularExports,
                 fixer,
-              );
-            },
+              ),
           });
         }
       }

--- a/src/rules/no-explicit-type-exports.ts
+++ b/src/rules/no-explicit-type-exports.ts
@@ -30,7 +30,9 @@ export = {
       const regularImports: string[] = [];
       const { ast } = context.getSourceCode();
       const { source } = node;
+
       const sourceName = source && 'value' in source ? source.value : undefined;
+
       if (typeof sourceName === 'string') {
         const typedExports = parseFileForExports(sourceName, context);
 
@@ -48,14 +50,20 @@ export = {
           );
 
           getExports(ast).forEach(exp => {
-            if (type === 'ExportNamedDeclaration') {
+            if (
+              type === 'ExportNamedDeclaration' &&
+              (node as TSESTree.ExportNamedDeclaration).exportKind !== 'type'
+            ) {
               context.report({
                 node,
                 message: errorMessage(exp),
                 fix: (fixer: RuleFixer) =>
                   exportFix(node, typedImports, regularImports, fixer),
               });
-            } else if (typedImports.includes(exp)) {
+            } else if (
+              typedImports.includes(exp) &&
+              (node as TSESTree.ImportDeclaration).importKind !== 'type'
+            ) {
               context.report({
                 node,
                 message: errorMessage(exp),
@@ -79,7 +87,10 @@ export = {
           },
         );
 
-        if (typedExports.length) {
+        if (
+          typedExports.length &&
+          (node as TSESTree.ExportNamedDeclaration).exportKind !== 'type'
+        ) {
           context.report({
             node,
             message: errorMessage(typedExports[0]),

--- a/src/rules/no-explicit-type-exports.ts
+++ b/src/rules/no-explicit-type-exports.ts
@@ -58,7 +58,12 @@ export = {
                 node,
                 message: errorMessage(exp),
                 fix: (fixer: RuleFixer) =>
-                  exportFix(node, typedImports, regularImports, fixer),
+                  exportFix(
+                    node as TSESTree.ExportNamedDeclaration,
+                    typedImports,
+                    regularImports,
+                    fixer,
+                  ),
               });
             } else if (
               typedImports.includes(exp) &&
@@ -68,7 +73,12 @@ export = {
                 node,
                 message: errorMessage(exp),
                 fix: (fixer: RuleFixer) =>
-                  importFixer(node, typedImports, regularImports, fixer),
+                  importFixer(
+                    node as TSESTree.ImportDeclaration,
+                    typedImports,
+                    regularImports,
+                    fixer,
+                  ),
               });
             }
           });
@@ -95,7 +105,12 @@ export = {
             node,
             message: errorMessage(typedExports[0]),
             fix: (fixer: RuleFixer) => {
-              exportFix(node, typedExports, regularExports, fixer);
+              exportFix(
+                node as TSESTree.ExportNamedDeclaration,
+                typedExports,
+                regularExports,
+                fixer,
+              );
             },
           });
         }

--- a/src/rules/no-explicit-type-exports.ts
+++ b/src/rules/no-explicit-type-exports.ts
@@ -26,8 +26,6 @@ export = {
     const getTypeImports = (type: string) => (
       node: TSESTree.ImportDeclaration | TSESTree.ExportNamedDeclaration,
     ): void => {
-      const typedImports: string[] = [];
-      const regularImports: string[] = [];
       const { ast } = context.getSourceCode();
       const { source } = node;
 
@@ -35,6 +33,8 @@ export = {
 
       if (typeof sourceName === 'string') {
         const typedExports = parseFileForExports(sourceName, context);
+        const typedImports: string[] = [];
+        const regularImports: string[] = [];
 
         if (typedExports) {
           node.specifiers.forEach(
@@ -52,6 +52,7 @@ export = {
           getExports(ast).forEach(exp => {
             if (
               type === 'ExportNamedDeclaration' &&
+              typedImports.includes(exp) &&
               (node as TSESTree.ExportNamedDeclaration).exportKind !== 'type'
             ) {
               context.report({
@@ -66,6 +67,7 @@ export = {
                   ),
               });
             } else if (
+              type === 'ImportDeclaration' &&
               typedImports.includes(exp) &&
               (node as TSESTree.ImportDeclaration).importKind !== 'type'
             ) {
@@ -96,7 +98,6 @@ export = {
             }
           },
         );
-
         if (
           typedExports.length &&
           (node as TSESTree.ExportNamedDeclaration).exportKind !== 'type'

--- a/src/rules/no-explicit-type-exports.ts
+++ b/src/rules/no-explicit-type-exports.ts
@@ -2,6 +2,8 @@ import { TSESTree } from '@typescript-eslint/experimental-utils';
 
 import parseFileForExports from './getTypeExports';
 import getExports from './getExports';
+import { exportFix, importFixer } from '../fix';
+import { RuleFixer } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
 
 function errorMessage(name: string): string {
   return `Do not export '${name}' it is an imported type or interface.`;
@@ -9,52 +11,84 @@ function errorMessage(name: string): string {
 
 export = {
   name: 'no-explicit-type-exports',
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+  },
   create: function(
     context: any,
   ): {
     ImportDeclaration: (node: TSESTree.ImportDeclaration) => void;
     ExportNamedDeclaration: (node: TSESTree.ExportNamedDeclaration) => void;
   } {
+    const AllTypedImports: string[] = [];
+
     const getTypeImports = (type: string) => (
       node: TSESTree.ImportDeclaration | TSESTree.ExportNamedDeclaration,
     ): void => {
       const typedImports: string[] = [];
+      const regularImports: string[] = [];
       const { ast } = context.getSourceCode();
       const { source } = node;
       const sourceName = source && 'value' in source ? source.value : undefined;
+      if (typeof sourceName === 'string') {
+        const typedExports = parseFileForExports(sourceName, context);
 
-      if (typeof sourceName !== 'string') {
-        return;
-      }
+        if (typedExports) {
+          node.specifiers.forEach(
+            (specifier: TSESTree.ExportSpecifier | TSESTree.ImportClause) => {
+              const { name } = specifier.local;
+              if (!typedExports.has(name)) {
+                regularImports.push(name);
+              } else {
+                typedImports.push(name);
+                AllTypedImports.push(name);
+              }
+            },
+          );
 
-      const typedExports = parseFileForExports(sourceName, context);
-
-      if (!typedExports) {
-        return;
-      }
-
-      node.specifiers.forEach(
-        (specifier: TSESTree.ExportSpecifier | TSESTree.ImportClause) => {
-          const { name } = specifier.local;
-
-          if (!typedExports.has(name)) {
-            return;
-          }
-
-          if (type === 'ExportNamedDeclaration') {
-            context.report(node, errorMessage(name));
-            return;
-          }
-
-          typedImports.push(name);
-        },
-      );
-
-      getExports(ast).forEach(exp => {
-        if (typedImports.includes(exp)) {
-          context.report(node, errorMessage(exp));
+          getExports(ast).forEach(exp => {
+            if (type === 'ExportNamedDeclaration') {
+              context.report({
+                node,
+                message: errorMessage(exp),
+                fix: (fixer: RuleFixer) =>
+                  exportFix(node, typedImports, regularImports, fixer),
+              });
+            } else if (typedImports.includes(exp)) {
+              context.report({
+                node,
+                message: errorMessage(exp),
+                fix: (fixer: RuleFixer) =>
+                  importFixer(node, typedImports, regularImports, fixer),
+              });
+            }
+          });
         }
-      });
+      } else if (type === 'ExportNamedDeclaration') {
+        const typedExports: string[] = [];
+        const regularExports: string[] = [];
+        node.specifiers.forEach(
+          (specifier: TSESTree.ExportSpecifier | TSESTree.ImportClause) => {
+            const { name } = specifier.local;
+            if (AllTypedImports.includes(name)) {
+              typedExports.push(name);
+            } else {
+              regularExports.push(name);
+            }
+          },
+        );
+
+        if (typedExports.length) {
+          context.report({
+            node,
+            message: errorMessage(typedExports[0]),
+            fix: (fixer: RuleFixer) => {
+              exportFix(node, typedExports, regularExports, fixer);
+            },
+          });
+        }
+      }
     };
 
     return {

--- a/tests/files/oneLine.ts
+++ b/tests/files/oneLine.ts
@@ -1,1 +1,2 @@
 export type x = keyof typeof String;
+export type w = keyof typeof String;

--- a/tests/files/oneLine.ts
+++ b/tests/files/oneLine.ts
@@ -1,2 +1,1 @@
 export type x = keyof typeof String;
-export type w = keyof typeof String;

--- a/tests/no-explicit-type-exports.test.ts
+++ b/tests/no-explicit-type-exports.test.ts
@@ -7,7 +7,6 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
   },
-
   parser: parser,
   settings: {
     'import/resolver': {
@@ -51,8 +50,27 @@ ruleTester.run('no-explicit-type-exports', rule, {
     {
       // The rule fails when you export an imported interface
       filename: fileName,
-      code: "import baz, {bar, foo} from './bar'; export {bar}",
+      code: "import {bar} from './bar'; export {bar};",
+      output: "import type { bar } from './bar'; export {bar};",
       errors: [
+        {
+          message: "Do not export 'bar' it is an imported type or interface.",
+        },
+        {
+          message: "Do not export 'bar' it is an imported type or interface.",
+        },
+      ],
+    },
+    {
+      // The rule fails when you export an imported interface
+      filename: fileName,
+      code: "import baz, {bar, foo} from './bar'; export {bar};",
+      output:
+        "import type { bar,foo } from './bar';import { baz } from './bar'; export {bar};",
+      errors: [
+        {
+          message: "Do not export 'bar' it is an imported type or interface.",
+        },
         {
           message: "Do not export 'bar' it is an imported type or interface.",
         },
@@ -61,8 +79,13 @@ ruleTester.run('no-explicit-type-exports', rule, {
     {
       // The rule fails when you export an imported type
       filename: fileName,
-      code: "import baz, {bar, foo} from './bar'; export {foo}",
+      code: "import baz, {bar, foo} from './bar'; export {foo};",
+      output:
+        "import type { bar,foo } from './bar';import { baz } from './bar'; export {foo};",
       errors: [
+        {
+          message: "Do not export 'foo' it is an imported type or interface.",
+        },
         {
           message: "Do not export 'foo' it is an imported type or interface.",
         },
@@ -71,8 +94,12 @@ ruleTester.run('no-explicit-type-exports', rule, {
     {
       // The rule fails when you export an imported type (single line type)
       filename: fileName,
-      code: "import {baz} from './foo'; export {baz}",
+      code: "import {baz} from './foo'; export {baz};",
+      output: "import type { baz } from './foo'; export {baz};",
       errors: [
+        {
+          message: "Do not export 'baz' it is an imported type or interface.",
+        },
         {
           message: "Do not export 'baz' it is an imported type or interface.",
         },
@@ -81,8 +108,12 @@ ruleTester.run('no-explicit-type-exports', rule, {
     {
       // The rule fails when you export an imported interface (single line interface)
       filename: fileName,
-      code: "import {foo} from './foo'; export {foo}",
+      code: "import {foo} from './foo'; export {foo};",
+      output: "import type { foo } from './foo'; export {foo};",
       errors: [
+        {
+          message: "Do not export 'foo' it is an imported type or interface.",
+        },
         {
           message: "Do not export 'foo' it is an imported type or interface.",
         },
@@ -91,8 +122,12 @@ ruleTester.run('no-explicit-type-exports', rule, {
     {
       // The rule fails when you export an imported default type
       filename: fileName,
-      code: "import aType from './default'; export {aType}",
+      code: "import aType from './default'; export {aType};",
+      output: "import type { aType } from './default'; export {aType};",
       errors: [
+        {
+          message: "Do not export 'aType' it is an imported type or interface.",
+        },
         {
           message: "Do not export 'aType' it is an imported type or interface.",
         },
@@ -101,7 +136,8 @@ ruleTester.run('no-explicit-type-exports', rule, {
     {
       // The rule fails when you export default a type.
       filename: fileName,
-      code: "import aType from './default'; export default aType",
+      code: "import aType from './default'; export default aType;",
+      output: "import type { aType } from './default'; export default aType;",
       errors: [
         {
           message: "Do not export 'aType' it is an imported type or interface.",
@@ -112,6 +148,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when export and import a type or interface on a single line
       filename: fileName,
       code: "export { x } from './oneLine'",
+      output: "export type { x } from './oneLine';",
       errors: [
         {
           message: "Do not export 'x' it is an imported type or interface.",
@@ -121,7 +158,9 @@ ruleTester.run('no-explicit-type-exports', rule, {
     {
       // The rule fails multiple times.
       filename: fileName,
-      code: "import foo, {bar, foo, baz} from './bar'; export {bar, foo};",
+      code: "import foo, {bar, baz} from './bar'; export {bar, foo};",
+      output:
+        "import type { foo,bar } from './bar';import { baz } from './bar'; export {bar, foo};",
       errors: [
         {
           message: "Do not export 'bar' it is an imported type or interface.",
@@ -129,13 +168,21 @@ ruleTester.run('no-explicit-type-exports', rule, {
         {
           message: "Do not export 'foo' it is an imported type or interface.",
         },
+        {
+          message: "Do not export 'bar' it is an imported type or interface.",
+        },
       ],
     },
     {
       // The rule fails when exporting a type in an export with multiple exports
       filename: fileName,
-      code: "import foo, {bar, foo, baz} from './bar'; export {baz, foo};",
+      code: "import {bar, foo, baz} from './bar'; export {baz, foo};",
+      output:
+        "import type { bar,foo } from './bar';import { baz } from './bar'; export {baz, foo};",
       errors: [
+        {
+          message: "Do not export 'foo' it is an imported type or interface.",
+        },
         {
           message: "Do not export 'foo' it is an imported type or interface.",
         },
@@ -144,8 +191,13 @@ ruleTester.run('no-explicit-type-exports', rule, {
     {
       // The rule fails when exporting a type in an export with multiple export
       filename: fileName,
-      code: "import foo, {bar, foo, baz} from './bar'; export {foo, baz};",
+      code: "import foo, {bar, baz} from './bar'; export {foo, baz};",
+      output:
+        "import type { foo,bar } from './bar';import { baz } from './bar'; export {foo, baz};",
       errors: [
+        {
+          message: "Do not export 'foo' it is an imported type or interface.",
+        },
         {
           message: "Do not export 'foo' it is an imported type or interface.",
         },
@@ -154,12 +206,58 @@ ruleTester.run('no-explicit-type-exports', rule, {
     {
       // The rule fails when there are extra imports in the file.
       filename: fileName,
-      code: "import {aType} from './randomImports'; export {aType}",
+      code: "import {aType} from './randomImports'; export {aType};",
+      output: "import type { aType } from './randomImports'; export {aType};",
       errors: [
+        {
+          message: "Do not export 'aType' it is an imported type or interface.",
+        },
         {
           message: "Do not export 'aType' it is an imported type or interface.",
         },
       ],
     },
+    {
+      // The rule fails when export and import a type or interface on a single line
+      filename: fileName,
+      code: "import { x } from './oneLine'; export { x };",
+      output: "import type { x } from './oneLine'; export type { x };",
+      errors: [
+        {
+          message: "Do not export 'x' it is an imported type or interface.",
+        },
+        {
+          message: "Do not export 'x' it is an imported type or interface.",
+        },
+      ],
+    },
+    {
+      // The rule fails when export and import a type or interface on a single line
+      filename: fileName,
+      code:
+        "import { x } from './oneLine';import {bar} from './bar'; export {bar}; export { x };",
+      output: "import type { x } from './oneLine'; export type { x };",
+      errors: [
+        {
+          message: "Do not export 'x' it is an imported type or interface.",
+        },
+        {
+          message: "Do not export 'bar' it is an imported type or interface.",
+        },
+        {
+          message: "Do not export 'bar' it is an imported type or interface.",
+        },
+        {
+          message: "Do not export 'x' it is an imported type or interface.",
+        },
+      ],
+    },
+    //TODO: NOT AN ERROR https://github.com/eslint/eslint/issues/11187
+    // {
+    //   // The rule fails when export and import a type or interface on a single line
+    //   filename: fileName,
+    //   code: "import type { x } from './oneLine'; export type { x };",
+    //   output: "import type { x } from './oneLine'; export type { x };",
+    // },
   ],
 });

--- a/tests/no-explicit-type-exports.test.ts
+++ b/tests/no-explicit-type-exports.test.ts
@@ -66,7 +66,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when you export an imported interface
       filename: fileName,
       code: "import {bar} from './bar'; export {bar};",
-      output: "import type { bar } from './bar'; export type { bar };",
+      output: "import type { bar } from './bar';\n export type { bar };\n",
       errors: [
         {
           message: "Do not export 'bar' it is an imported type or interface.",
@@ -81,7 +81,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import baz, {bar, foo} from './bar'; export {bar};",
       output:
-        "import type { bar,foo } from './bar';import { baz } from './bar'; export type { bar };",
+        "import type { bar,foo } from './bar';\nimport { baz } from './bar'; export type { bar };\n",
       errors: [
         {
           message: "Do not export 'bar' it is an imported type or interface.",
@@ -96,7 +96,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import baz, {bar, foo} from './bar'; export {foo};",
       output:
-        "import type { bar,foo } from './bar';import { baz } from './bar'; export type { foo };",
+        "import type { bar,foo } from './bar';\nimport { baz } from './bar'; export type { foo };\n",
       errors: [
         {
           message: "Do not export 'foo' it is an imported type or interface.",
@@ -110,7 +110,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when you export an imported type (single line type)
       filename: fileName,
       code: "import {baz} from './foo'; export {baz};",
-      output: "import type { baz } from './foo'; export type { baz };",
+      output: "import type { baz } from './foo';\n export type { baz };\n",
       errors: [
         {
           message: "Do not export 'baz' it is an imported type or interface.",
@@ -124,7 +124,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when you export an imported interface (single line interface)
       filename: fileName,
       code: "import {foo} from './foo'; export {foo};",
-      output: "import type { foo } from './foo'; export type { foo };",
+      output: "import type { foo } from './foo';\n export type { foo };\n",
       errors: [
         {
           message: "Do not export 'foo' it is an imported type or interface.",
@@ -138,7 +138,8 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when you export an imported default type
       filename: fileName,
       code: "import aType from './default'; export {aType};",
-      output: "import type { aType } from './default'; export type { aType };",
+      output:
+        "import type { aType } from './default';\n export type { aType };\n",
       errors: [
         {
           message: "Do not export 'aType' it is an imported type or interface.",
@@ -152,7 +153,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when you export default a type.
       filename: fileName,
       code: "import aType from './default'; export default aType;",
-      output: "import type { aType } from './default'; export default aType;",
+      output: "import type { aType } from './default';\n export default aType;",
       errors: [
         {
           message: "Do not export 'aType' it is an imported type or interface.",
@@ -163,7 +164,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when export and import a type or interface on a single line
       filename: fileName,
       code: "export { x } from './oneLine'",
-      output: "export type { x } from './oneLine';",
+      output: "export type { x } from './oneLine';\n",
       errors: [
         {
           message: "Do not export 'x' it is an imported type or interface.",
@@ -175,7 +176,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import foo, {bar, baz} from './bar'; export {bar, foo};",
       output:
-        "import type { foo,bar } from './bar';import { baz } from './bar'; export type { bar,foo };",
+        "import type { foo,bar } from './bar';\nimport { baz } from './bar'; export type { bar,foo };\n",
       errors: [
         {
           message: "Do not export 'bar' it is an imported type or interface.",
@@ -193,7 +194,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import {bar, foo, baz} from './bar'; export {baz, foo};",
       output:
-        "import type { bar,foo } from './bar';import { baz } from './bar'; export type { foo };export { baz };",
+        "import type { bar,foo } from './bar';\nimport { baz } from './bar'; export type { foo };\nexport { baz };",
       errors: [
         {
           message: "Do not export 'foo' it is an imported type or interface.",
@@ -208,7 +209,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import foo, {bar, baz} from './bar'; export {foo, baz};",
       output:
-        "import type { foo,bar } from './bar';import { baz } from './bar'; export type { foo };export { baz };",
+        "import type { foo,bar } from './bar';\nimport { baz } from './bar'; export type { foo };\nexport { baz };",
       errors: [
         {
           message: "Do not export 'foo' it is an imported type or interface.",
@@ -223,7 +224,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import {aType} from './randomImports'; export {aType};",
       output:
-        "import type { aType } from './randomImports'; export type { aType };",
+        "import type { aType } from './randomImports';\n export type { aType };\n",
       errors: [
         {
           message: "Do not export 'aType' it is an imported type or interface.",
@@ -237,7 +238,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when export and import a type or interface on a single line
       filename: fileName,
       code: "import type { x } from './oneLine'; export { x };",
-      output: "import type { x } from './oneLine'; export type { x };",
+      output: "import type { x } from './oneLine'; export type { x };\n",
       errors: [
         {
           message: "Do not export 'x' it is an imported type or interface.",
@@ -250,7 +251,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       code:
         "import type { x } from './oneLine';import {bar} from './bar'; export {bar}; export { x };",
       output:
-        "import type { x } from './oneLine';import type { bar } from './bar'; export type { bar }; export type { x };",
+        "import type { x } from './oneLine';import type { bar } from './bar';\n export type { bar };\n export type { x };\n",
       errors: [
         {
           message: "Do not export 'bar' it is an imported type or interface.",
@@ -267,7 +268,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when export and import a type or interface on a single line
       filename: fileName,
       code: "import { x } from './oneLine'; export type { x };",
-      output: "import type { x } from './oneLine'; export type { x };",
+      output: "import type { x } from './oneLine';\n export type { x };",
       errors: [
         {
           message: "Do not export 'x' it is an imported type or interface.",
@@ -278,7 +279,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails single line imported/exported  types
       filename: fileName,
       code: "export { foo, baz } from './bar';",
-      output: "export type { foo } from './bar';export { baz } from './bar';",
+      output: "export type { foo } from './bar';\nexport { baz } from './bar';",
       errors: [
         {
           message: "Do not export 'foo' it is an imported type or interface.",

--- a/tests/no-explicit-type-exports.test.ts
+++ b/tests/no-explicit-type-exports.test.ts
@@ -50,6 +50,16 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import type { x } from './oneLine'; export type { x };",
     },
+    {
+      // The rule passes when export and import a type or interface on a single line
+      filename: fileName,
+      code: "export type { foo } from './bar';",
+    },
+    {
+      // The rule passes when export and import a type or interface on a single line
+      filename: fileName,
+      code: "export type { foo } from './bar'; export  { baz } from './bar';",
+    },
   ],
   invalid: [
     {
@@ -261,6 +271,17 @@ ruleTester.run('no-explicit-type-exports', rule, {
       errors: [
         {
           message: "Do not export 'x' it is an imported type or interface.",
+        },
+      ],
+    },
+    {
+      // The rule fails single line imported/exported  types
+      filename: fileName,
+      code: "export { foo, baz } from './bar';",
+      output: "export type { foo } from './bar';export { baz } from './bar';",
+      errors: [
+        {
+          message: "Do not export 'foo' it is an imported type or interface.",
         },
       ],
     },

--- a/tests/no-explicit-type-exports.test.ts
+++ b/tests/no-explicit-type-exports.test.ts
@@ -56,7 +56,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when you export an imported interface
       filename: fileName,
       code: "import {bar} from './bar'; export {bar};",
-      output: "import type { bar } from './bar'; export {bar};",
+      output: "import type { bar } from './bar'; export type { bar };",
       errors: [
         {
           message: "Do not export 'bar' it is an imported type or interface.",
@@ -71,7 +71,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import baz, {bar, foo} from './bar'; export {bar};",
       output:
-        "import type { bar,foo } from './bar';import { baz } from './bar'; export {bar};",
+        "import type { bar,foo } from './bar';import { baz } from './bar'; export type { bar };",
       errors: [
         {
           message: "Do not export 'bar' it is an imported type or interface.",
@@ -86,7 +86,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import baz, {bar, foo} from './bar'; export {foo};",
       output:
-        "import type { bar,foo } from './bar';import { baz } from './bar'; export {foo};",
+        "import type { bar,foo } from './bar';import { baz } from './bar'; export type { foo };",
       errors: [
         {
           message: "Do not export 'foo' it is an imported type or interface.",
@@ -100,7 +100,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when you export an imported type (single line type)
       filename: fileName,
       code: "import {baz} from './foo'; export {baz};",
-      output: "import type { baz } from './foo'; export {baz};",
+      output: "import type { baz } from './foo'; export type { baz };",
       errors: [
         {
           message: "Do not export 'baz' it is an imported type or interface.",
@@ -114,7 +114,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when you export an imported interface (single line interface)
       filename: fileName,
       code: "import {foo} from './foo'; export {foo};",
-      output: "import type { foo } from './foo'; export {foo};",
+      output: "import type { foo } from './foo'; export type { foo };",
       errors: [
         {
           message: "Do not export 'foo' it is an imported type or interface.",
@@ -128,7 +128,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when you export an imported default type
       filename: fileName,
       code: "import aType from './default'; export {aType};",
-      output: "import type { aType } from './default'; export {aType};",
+      output: "import type { aType } from './default'; export type { aType };",
       errors: [
         {
           message: "Do not export 'aType' it is an imported type or interface.",
@@ -165,7 +165,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import foo, {bar, baz} from './bar'; export {bar, foo};",
       output:
-        "import type { foo,bar } from './bar';import { baz } from './bar'; export {bar, foo};",
+        "import type { foo,bar } from './bar';import { baz } from './bar'; export type { bar,foo };",
       errors: [
         {
           message: "Do not export 'bar' it is an imported type or interface.",
@@ -183,7 +183,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import {bar, foo, baz} from './bar'; export {baz, foo};",
       output:
-        "import type { bar,foo } from './bar';import { baz } from './bar'; export {baz, foo};",
+        "import type { bar,foo } from './bar';import { baz } from './bar'; export type { foo };export { baz };",
       errors: [
         {
           message: "Do not export 'foo' it is an imported type or interface.",
@@ -198,7 +198,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import foo, {bar, baz} from './bar'; export {foo, baz};",
       output:
-        "import type { foo,bar } from './bar';import { baz } from './bar'; export {foo, baz};",
+        "import type { foo,bar } from './bar';import { baz } from './bar'; export type { foo };export { baz };",
       errors: [
         {
           message: "Do not export 'foo' it is an imported type or interface.",
@@ -212,7 +212,8 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when there are extra imports in the file.
       filename: fileName,
       code: "import {aType} from './randomImports'; export {aType};",
-      output: "import type { aType } from './randomImports'; export {aType};",
+      output:
+        "import type { aType } from './randomImports'; export type { aType };",
       errors: [
         {
           message: "Do not export 'aType' it is an imported type or interface.",
@@ -226,7 +227,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when export and import a type or interface on a single line
       filename: fileName,
       code: "import type { x } from './oneLine'; export { x };",
-      output: "import type { x } from './oneLine'; export { x };",
+      output: "import type { x } from './oneLine'; export type { x };",
       errors: [
         {
           message: "Do not export 'x' it is an imported type or interface.",
@@ -239,7 +240,7 @@ ruleTester.run('no-explicit-type-exports', rule, {
       code:
         "import type { x } from './oneLine';import {bar} from './bar'; export {bar}; export { x };",
       output:
-        "import type { x } from './oneLine';import type { bar } from './bar'; export {bar}; export { x };",
+        "import type { x } from './oneLine';import type { bar } from './bar'; export type { bar }; export type { x };",
       errors: [
         {
           message: "Do not export 'bar' it is an imported type or interface.",

--- a/tests/no-explicit-type-exports.test.ts
+++ b/tests/no-explicit-type-exports.test.ts
@@ -45,6 +45,11 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: "import {bar} from './bar';",
     },
+    {
+      // The rule passes when export and import a type or interface on a single line
+      filename: fileName,
+      code: "import type { x } from './oneLine'; export type { x };",
+    },
   ],
   invalid: [
     {
@@ -220,12 +225,9 @@ ruleTester.run('no-explicit-type-exports', rule, {
     {
       // The rule fails when export and import a type or interface on a single line
       filename: fileName,
-      code: "import { x } from './oneLine'; export { x };",
-      output: "import type { x } from './oneLine'; export type { x };",
+      code: "import type { x } from './oneLine'; export { x };",
+      output: "import type { x } from './oneLine'; export { x };",
       errors: [
-        {
-          message: "Do not export 'x' it is an imported type or interface.",
-        },
         {
           message: "Do not export 'x' it is an imported type or interface.",
         },
@@ -235,12 +237,10 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule fails when export and import a type or interface on a single line
       filename: fileName,
       code:
-        "import { x } from './oneLine';import {bar} from './bar'; export {bar}; export { x };",
-      output: "import type { x } from './oneLine'; export type { x };",
+        "import type { x } from './oneLine';import {bar} from './bar'; export {bar}; export { x };",
+      output:
+        "import type { x } from './oneLine';import type { bar } from './bar'; export {bar}; export { x };",
       errors: [
-        {
-          message: "Do not export 'x' it is an imported type or interface.",
-        },
         {
           message: "Do not export 'bar' it is an imported type or interface.",
         },
@@ -252,12 +252,16 @@ ruleTester.run('no-explicit-type-exports', rule, {
         },
       ],
     },
-    //TODO: NOT AN ERROR https://github.com/eslint/eslint/issues/11187
-    // {
-    //   // The rule fails when export and import a type or interface on a single line
-    //   filename: fileName,
-    //   code: "import type { x } from './oneLine'; export type { x };",
-    //   output: "import type { x } from './oneLine'; export type { x };",
-    // },
+    {
+      // The rule fails when export and import a type or interface on a single line
+      filename: fileName,
+      code: "import { x } from './oneLine'; export type { x };",
+      output: "import type { x } from './oneLine'; export type { x };",
+      errors: [
+        {
+          message: "Do not export 'x' it is an imported type or interface.",
+        },
+      ],
+    },
   ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,45 +559,46 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.5.0":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.1.tgz#e34972a24f8aba0861f9ccf7130acd74fd11e079"
-  integrity sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==
+"@typescript-eslint/eslint-plugin@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.26.0.tgz#04c96560c8981421e5a9caad8394192363cc423f"
+  integrity sha512-4yUnLv40bzfzsXcTAtZyTjbiGUXMrcIJcIMioI22tSOyAxpdXiZ4r7YQUU8Jj6XXrLz9d5aMHPQf5JFR7h27Nw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.6.1"
-    eslint-utils "^1.4.2"
+    "@typescript-eslint/experimental-utils" "2.26.0"
     functional-red-black-tree "^1.0.1"
-    regexpp "^2.0.1"
+    regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.6.1", "@typescript-eslint/experimental-utils@^2.4.0":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.1.tgz#eddaca17a399ebf93a8628923233b4f93793acfd"
-  integrity sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==
+"@typescript-eslint/experimental-utils@2.26.0", "@typescript-eslint/experimental-utils@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.26.0.tgz#063390c404d9980767d76274df386c0aa675d91d"
+  integrity sha512-RELVoH5EYd+JlGprEyojUv9HeKcZqF7nZUGSblyAw1FwOGNnmQIU8kxJ69fttQvEwCsX5D6ECJT8GTozxrDKVQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.6.1"
+    "@typescript-eslint/typescript-estree" "2.26.0"
     eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^2.5.0":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.6.1.tgz#3c00116baa0d696bc334ca18ac5286b34793993c"
-  integrity sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==
+"@typescript-eslint/parser@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.26.0.tgz#385463615818b33acb72a25b39c03579df93d76f"
+  integrity sha512-+Xj5fucDtdKEVGSh9353wcnseMRkPpEAOY96EEenN7kJVrLqy/EVwtIh3mxcUz8lsFXW1mT5nN5vvEam/a5HiQ==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.6.1"
-    "@typescript-eslint/typescript-estree" "2.6.1"
+    "@typescript-eslint/experimental-utils" "2.26.0"
+    "@typescript-eslint/typescript-estree" "2.26.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.6.1", "@typescript-eslint/typescript-estree@^2.4.0":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.1.tgz#fb363dd4ca23384745c5ea4b7f4c867432b00d31"
-  integrity sha512-+sTnssW6bcbDZKE8Ce7VV6LdzkQz2Bxk7jzk1J8H1rovoTxnm6iXvYIyncvNsaB/kBCOM63j/LNJfm27bNdUoA==
+"@typescript-eslint/typescript-estree@2.26.0", "@typescript-eslint/typescript-estree@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.26.0.tgz#d8132cf1ee8a72234f996519a47d8a9118b57d56"
+  integrity sha512-3x4SyZCLB4zsKsjuhxDLeVJN6W29VwBnYpCsZ7vIdPel9ZqLfIZJgJXO47MNUkurGpQuIBALdPQKtsSnWpE1Yg==
   dependencies:
     debug "^4.1.1"
-    glob "^7.1.4"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
     is-glob "^4.0.1"
-    lodash.unescape "4.0.1"
+    lodash "^4.17.15"
     semver "^6.3.0"
     tsutils "^3.17.1"
 
@@ -1528,10 +1529,17 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.4.2, eslint-utils@^1.4.3:
+eslint-utils@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
   integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
@@ -1965,7 +1973,7 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -3048,11 +3056,6 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash.unescape@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
-  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
-
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -3842,6 +3845,11 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
+regexpp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
+  integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
+
 registry-url@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-5.1.0.tgz#e98334b50d5434b81136b44ec638d9c2009c5009"
@@ -4605,10 +4613,10 @@ typescript-memoize@^1.0.0-alpha.3:
   dependencies:
     core-js "2.4.1"
 
-typescript@^3.6.4:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@^3.8.1-rc:
+  version "3.8.1-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.1-rc.tgz#f94333c14da70927ccd887be2e91be652a9a09f6"
+  integrity sha512-aOIe066DyZn2uYIiND6fXMUUJ70nxwu/lKhA92QuQzXyC86fr0ywo1qvO8l2m0EnDcfjprYPuFRgNgDj7U2GlQ==
 
 typical@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,40 +559,40 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.26.0":
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.26.0.tgz#04c96560c8981421e5a9caad8394192363cc423f"
-  integrity sha512-4yUnLv40bzfzsXcTAtZyTjbiGUXMrcIJcIMioI22tSOyAxpdXiZ4r7YQUU8Jj6XXrLz9d5aMHPQf5JFR7h27Nw==
+"@typescript-eslint/eslint-plugin@^2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.27.0.tgz#e479cdc4c9cf46f96b4c287755733311b0d0ba4b"
+  integrity sha512-/my+vVHRN7zYgcp0n4z5A6HAK7bvKGBiswaM5zIlOQczsxj/aiD7RcgD+dvVFuwFaGh5+kM7XA6Q6PN0bvb1tw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.26.0"
+    "@typescript-eslint/experimental-utils" "2.27.0"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.26.0", "@typescript-eslint/experimental-utils@^2.26.0":
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.26.0.tgz#063390c404d9980767d76274df386c0aa675d91d"
-  integrity sha512-RELVoH5EYd+JlGprEyojUv9HeKcZqF7nZUGSblyAw1FwOGNnmQIU8kxJ69fttQvEwCsX5D6ECJT8GTozxrDKVQ==
+"@typescript-eslint/experimental-utils@2.27.0", "@typescript-eslint/experimental-utils@^2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz#801a952c10b58e486c9a0b36cf21e2aab1e9e01a"
+  integrity sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.26.0"
+    "@typescript-eslint/typescript-estree" "2.27.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^2.26.0":
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.26.0.tgz#385463615818b33acb72a25b39c03579df93d76f"
-  integrity sha512-+Xj5fucDtdKEVGSh9353wcnseMRkPpEAOY96EEenN7kJVrLqy/EVwtIh3mxcUz8lsFXW1mT5nN5vvEam/a5HiQ==
+"@typescript-eslint/parser@^2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.27.0.tgz#d91664335b2c46584294e42eb4ff35838c427287"
+  integrity sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.26.0"
-    "@typescript-eslint/typescript-estree" "2.26.0"
+    "@typescript-eslint/experimental-utils" "2.27.0"
+    "@typescript-eslint/typescript-estree" "2.27.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.26.0", "@typescript-eslint/typescript-estree@^2.26.0":
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.26.0.tgz#d8132cf1ee8a72234f996519a47d8a9118b57d56"
-  integrity sha512-3x4SyZCLB4zsKsjuhxDLeVJN6W29VwBnYpCsZ7vIdPel9ZqLfIZJgJXO47MNUkurGpQuIBALdPQKtsSnWpE1Yg==
+"@typescript-eslint/typescript-estree@2.27.0", "@typescript-eslint/typescript-estree@^2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz#a288e54605412da8b81f1660b56c8b2e42966ce8"
+  integrity sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -4613,10 +4613,10 @@ typescript-memoize@^1.0.0-alpha.3:
   dependencies:
     core-js "2.4.1"
 
-typescript@^3.8.1-rc:
-  version "3.8.1-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.1-rc.tgz#f94333c14da70927ccd887be2e91be652a9a09f6"
-  integrity sha512-aOIe066DyZn2uYIiND6fXMUUJ70nxwu/lKhA92QuQzXyC86fr0ywo1qvO8l2m0EnDcfjprYPuFRgNgDj7U2GlQ==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# What Changed

you now will be able to use --fix when running this eslint-plugin

the fix command will add the 'type' operator to all types and interfaces that are imported then exported from a file.

example:

this:
```
import { SomeThing } from "./some-module.js";
export { SomeThing };

```
will be fixed to:

```
import type { SomeThing } from "./some-module.js"; 
export type { SomeThing };

```


# Why

https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports




Todo:
-- I would like to wait to merge this when I update to a non 'beta' version of typescript and  typescript-eslint supports 3.8.1
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `0.11.0-canary.6.106`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
