### PR TITLE
Adding passing test case: import type * as types from './bar'; export type {types};

### DIFF
--- a/tests/no-explicit-type-exports.test.ts
+++ b/tests/no-explicit-type-exports.test.ts
@@ -65,6 +65,11 @@ ruleTester.run('no-explicit-type-exports', rule, {
       filename: fileName,
       code: " export * from './bar';",
     },
+    {
+      // The rule passes when a file imports * from a file and exports as a single variable
+      filename: fileName,
+      code: "import type * as types from './bar'; export type {types};",
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
# What Changed
Added a passing test case to test a rule for importing all modules and exporting as a single variable.
# Why
Solves #10 
Todo:
- [x] Add Semantic Version Label 
- [x] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `0.11.6-canary.15.178`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
