### PR TITLE
Adding passing test case: import type * as types from ‘./file; export {types}

### DIFF
--- a/tests/no-explicit-type-exports.test.ts
+++ b/tests/no-explicit-type-exports.test.ts
@@ -66,9 +66,14 @@ ruleTester.run('no-explicit-type-exports', rule, {
       code: " export * from './bar';",
     },
     {
-      // The rule passes when a file imports * from a file and exports as a single variable
+      // The rule passes when a file imports * from a file and exports as a single type variable
       filename: fileName,
       code: "import type * as types from './bar'; export type {types};",
+    },
+    {
+      // The rule passes when a file imports * from a file and exports as a single variable
+      filename: fileName,
+      code: "import type * as types from './bar'; export {types};",
     },
   ],
   invalid: [


### PR DESCRIPTION
# What Changed
Adding a passing test case to test a rule for importing all modules and exporting as a single variable.

# Why
Fixes: #11 

Todo:
- [ ] Add Semantic Version Label 
- [ ] Add tests
- [ ] Add docs
