### PR TITLE
Fix auto to update all contributors on release

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -39,7 +39,7 @@
         "code"
       ]
     },
-        {
+    {
       "login": "rajatdiptabiswas",
       "name": "Rajat Biswas",
       "avatar_url": "https://avatars.githubusercontent.com/rajatdiptabiswas",
@@ -47,8 +47,7 @@
       "contributions": [
         "code"
       ]
-    },
-
+    }
   ],
   "contributorsPerLine": 7
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -25,7 +25,7 @@
       "login": "hipstersmoothie",
       "name": "Andrew Lisowski",
       "avatar_url": "https://avatars3.githubusercontent.com/u/1192452?v=4",
-      "profile": "https://github.intuit.com/hipstersmoothie",
+      "profile": "https://github.com/hipstersmoothie",
       "contributions": [
         "doc"
       ]
@@ -34,11 +34,21 @@
       "login": "Rashmi-K-A",
       "name": "Rashmi K A",
       "avatar_url": "https://avatars2.githubusercontent.com/u/39820442?v=4",
-      "profile": "https://github.intuit.com/Rashmi-K-A",
+      "profile": "https://github.com/Rashmi-K-A",
       "contributions": [
         "code"
       ]
     },
+        {
+      "login": "rajatdiptabiswas",
+      "name": "Rajat Biswas",
+      "avatar_url": "https://avatars.githubusercontent.com/rajatdiptabiswas",
+      "profile": "https://github.com/rajatdiptabiswas",
+      "contributions": [
+        "code"
+      ]
+    },
+
   ],
   "contributorsPerLine": 7
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf ./dist && rimraf node_modules",
     "lint": "eslint ./src --ext .js,.ts",
     "test": "jest --coverage",
-    "release": "auto shipit",
+    "release": "auto shipit -vv",
     "labelCheck": "auto pr-check"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf ./dist && rimraf node_modules",
     "lint": "eslint ./src --ext .js,.ts",
     "test": "jest --coverage",
-    "release": "auto shipit -vv",
+    "release": "auto shipit",
     "labelCheck": "auto pr-check"
   },
   "engines": {


### PR DESCRIPTION
# What Changed

# Why

Todo:
- [ ] Add Semantic Version Label 
- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.11.9-canary.19.255.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-plugin-no-explicit-type-exports@0.11.9-canary.19.255.0
  # or 
  yarn add eslint-plugin-no-explicit-type-exports@0.11.9-canary.19.255.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
