### PR TITLE
Bump auto version to get all contributors errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "eslint": ">= 6.x"
   },
   "devDependencies": {
-    "@auto-it/all-contributors": "^9.53.1",
+    "@auto-it/all-contributors": "^9.54.6",
     "@types/eslint": "^6.1.2",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.11.5",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",
     "@typescript-eslint/typescript-estree": "^2.27.0",
-    "auto": "^9.53.1",
+    "auto": "^9.54.6",
     "eslint": "^6.5.1",
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-prettier": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@auto-it/all-contributors": "^9.54.6",
+    "all-contributors-cli": "^6.16.1",
     "@types/eslint": "^6.1.2",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.11.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@auto-it/all-contributors": "^9.54.6",
-    "all-contributors-cli": "^6.16.1",
     "@types/eslint": "^6.1.2",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.11.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,6 +819,22 @@ all-contributors-cli@6.17.4:
     pify "^5.0.0"
     yargs "^15.0.1"
 
+all-contributors-cli@^6.16.1:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/all-contributors-cli/-/all-contributors-cli-6.18.0.tgz#616802b57b10ea20971f0275391f79d322136e1b"
+  integrity sha512-Dy90FtqKZ0TKmjWF3rkJUJzENW7O57mHL4B7JE7nziGjnSSLjGek9VeGAgCfluU037ENj4BKYbsB4oB/op+xFA==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+    async "^3.0.1"
+    chalk "^4.0.0"
+    didyoumean "^1.2.1"
+    inquirer "^7.0.4"
+    json-fixer "^1.5.1"
+    lodash "^4.11.2"
+    node-fetch "^2.6.0"
+    pify "^5.0.0"
+    yargs "^15.0.1"
+
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,22 +819,6 @@ all-contributors-cli@6.17.4:
     pify "^5.0.0"
     yargs "^15.0.1"
 
-all-contributors-cli@^6.16.1:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/all-contributors-cli/-/all-contributors-cli-6.18.0.tgz#616802b57b10ea20971f0275391f79d322136e1b"
-  integrity sha512-Dy90FtqKZ0TKmjWF3rkJUJzENW7O57mHL4B7JE7nziGjnSSLjGek9VeGAgCfluU037ENj4BKYbsB4oB/op+xFA==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
-    async "^3.0.1"
-    chalk "^4.0.0"
-    didyoumean "^1.2.1"
-    inquirer "^7.0.4"
-    json-fixer "^1.5.1"
-    lodash "^4.11.2"
-    node-fetch "^2.6.0"
-    pify "^5.0.0"
-    yargs "^15.0.1"
-
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@auto-it/all-contributors@^9.53.1":
-  version "9.53.1"
-  resolved "https://registry.yarnpkg.com/@auto-it/all-contributors/-/all-contributors-9.53.1.tgz#c791ecc4a8a5ac73257bc2bc9285039d986ddb87"
-  integrity sha512-o8gxAzo0u3om0fn6t1i/HJXmSncA6KCTfK/P4YsgGpAxNuTEjkRVPPbcbq4tW84W/yErqKwTtSMCP+pSXev/rw==
+"@auto-it/all-contributors@^9.54.6":
+  version "9.54.6"
+  resolved "https://registry.yarnpkg.com/@auto-it/all-contributors/-/all-contributors-9.54.6.tgz#fbc1d17b8cc5e354405ce19237869ea9c9e53bca"
+  integrity sha512-qfGJ8qqsUstdM7cnWekS4+4yJKGfOAfOsf0F4eueEyN8AfleirSkWRGS8t46jUKc+VTiXFJuqPBONSNDnTtmlQ==
   dependencies:
-    "@auto-it/bot-list" "9.53.1"
-    "@auto-it/core" "9.53.1"
+    "@auto-it/bot-list" "9.54.6"
+    "@auto-it/core" "9.54.6"
     "@octokit/rest" "^18.0.0"
-    all-contributors-cli "6.17.2"
+    all-contributors-cli "6.17.4"
     anymatch "^3.1.1"
     await-to-js "^2.1.1"
     endent "^2.0.1"
@@ -20,64 +20,17 @@
     io-ts "^2.1.2"
     tslib "2.0.1"
 
-"@auto-it/bot-list@9.53.1":
-  version "9.53.1"
-  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.53.1.tgz#1d24ef4d3d2c202acccadd7e0d425a50e5b06e1c"
-  integrity sha512-zoQe27iSpGb6jRstaCbBMzU3UqcwzINX4Pi4hJLBrzA9Gd8K4BV7uKnlEqlDZruD+b4YBnrlqNsuQEB03UXP+A==
+"@auto-it/bot-list@9.54.6":
+  version "9.54.6"
+  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.54.6.tgz#c941850bbc2a730ef56428f527b4264bbb38c575"
+  integrity sha512-N3XTR/tqOyZYrSv4ojKoTYhVgyo2ADsem6TkUuSfTXEZyGzv1lnNe7vXQyAHme+D4TRejt1FSbwh/STdMRFbAg==
 
-"@auto-it/bot-list@9.54.3":
-  version "9.54.3"
-  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.54.3.tgz#afc816e423baa28692291ae483e0f7b5ff7c04a7"
-  integrity sha512-AbKmD5QNWKMz0B5WBrP2oAhTxOFNPItKOwfYY6xwmwfp+7E+g+QNFQZ885e6br4ReUuhwJmht386aL6dzmBm4A==
-
-"@auto-it/core@9.53.1":
-  version "9.53.1"
-  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.53.1.tgz#8b49e37f66a940c5ebc0cdfb83774633c16f0006"
-  integrity sha512-KZbWmhKsIn6bd/k6OjIhba+akCNTbst46ELdjLTu149jzGqzMn0vWONBFf1OtNJeLS1VUNfH6pjx7225GuZXTw==
+"@auto-it/core@9.54.6":
+  version "9.54.6"
+  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.54.6.tgz#5ca49812f000e48e4be5796532189badcc6b5f2b"
+  integrity sha512-ew6A8o8soyi7T9kuXC+mMJBNsxWf+LkDUCo+Oq3qLfoP2Xc7mQbmAIdWYFwWijYT3mhryPgc+AUZV+8WxpIx9g==
   dependencies:
-    "@auto-it/bot-list" "9.53.1"
-    "@octokit/plugin-enterprise-compatibility" "^1.2.2"
-    "@octokit/plugin-retry" "^3.0.1"
-    "@octokit/plugin-throttling" "^3.2.0"
-    "@octokit/rest" "^18.0.0"
-    await-to-js "^2.1.1"
-    chalk "^4.0.0"
-    cosmiconfig "7.0.0"
-    deepmerge "^4.0.0"
-    dotenv "^8.0.0"
-    endent "^2.0.1"
-    enquirer "^2.3.4"
-    env-ci "^5.0.1"
-    fast-glob "^3.1.1"
-    fp-ts "^2.5.3"
-    fromentries "^1.2.0"
-    gitlog "^4.0.0"
-    https-proxy-agent "^5.0.0"
-    import-cwd "^3.0.0"
-    import-from "^3.0.0"
-    io-ts "^2.1.2"
-    lodash.chunk "^4.2.0"
-    log-symbols "^4.0.0"
-    node-fetch "2.6.0"
-    parse-author "^2.0.0"
-    parse-github-url "1.0.2"
-    pretty-ms "^7.0.0"
-    semver "^7.0.0"
-    signale "^1.4.0"
-    tapable "^2.0.0-beta.2"
-    terminal-link "^2.1.1"
-    tinycolor2 "^1.4.1"
-    tslib "2.0.1"
-    type-fest "^0.16.0"
-    typescript-memoize "^1.0.0-alpha.3"
-    url-join "^4.0.0"
-
-"@auto-it/core@9.54.3":
-  version "9.54.3"
-  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.54.3.tgz#c91f63e81daa00878ec9c1b911786ea91c6b3712"
-  integrity sha512-VuO5iLVk+bqbIcLpFH7E3noqJs/yAi21bYNs5bTQIqx/oIlugC39FaUDqEiq6dNqIdQiu1zhrL5w+RRa/51Yhg==
-  dependencies:
-    "@auto-it/bot-list" "9.54.3"
+    "@auto-it/bot-list" "9.54.6"
     "@octokit/plugin-enterprise-compatibility" "^1.2.2"
     "@octokit/plugin-retry" "^3.0.1"
     "@octokit/plugin-throttling" "^3.2.0"
@@ -114,12 +67,12 @@
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
-"@auto-it/npm@9.54.3":
-  version "9.54.3"
-  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-9.54.3.tgz#8b14a58c2001b08b2fa968e3c817bba350a79d80"
-  integrity sha512-0pP1tCO6XqkkjA/qZjui5P9L2Gq22UvS8BsEjcEPipiXzoHfDtUEoJMmDtjxe0R0FRGdzaxXvhe1M+lpjaUUNw==
+"@auto-it/npm@9.54.6":
+  version "9.54.6"
+  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-9.54.6.tgz#2caf2051099b3ba93c7820922e752cbb91456c81"
+  integrity sha512-su9/y5EtgX8XOgcaEU+zBpBfacz2KXx7qSyPgSUo/HvWXBL+TCSzmr5TsgQfNG7DUUldgITBacXb5es9XWTSLQ==
   dependencies:
-    "@auto-it/core" "9.54.3"
+    "@auto-it/core" "9.54.6"
     await-to-js "^2.1.1"
     env-ci "^5.0.1"
     fp-ts "^2.5.3"
@@ -134,12 +87,12 @@
     url-join "^4.0.0"
     user-home "^2.0.0"
 
-"@auto-it/released@9.54.3":
-  version "9.54.3"
-  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-9.54.3.tgz#4c42fdec7a3ad1e1def83a459e6edc1816285b49"
-  integrity sha512-tCGFdQA5GihNXPKljBkY97YS9m2MxVZDB0V/l2gr3PEx3QVbz1YfN81+2BVrJVAIKu1zSZTQ0Lc9vyAJgJOkpQ==
+"@auto-it/released@9.54.6":
+  version "9.54.6"
+  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-9.54.6.tgz#36114f8612d2dfb4678f45ad7ff72dbaf29950e9"
+  integrity sha512-5imGPsb8TK12FxBk7Jc24hEN6i34ashXos576Luc9kpuCT3NnnwcCKlhf1cuAFJ2O35mDqbly7wmTGD1z/iOpw==
   dependencies:
-    "@auto-it/core" "9.54.3"
+    "@auto-it/core" "9.54.6"
     deepmerge "^4.0.0"
     fp-ts "^2.5.3"
     io-ts "^2.1.2"
@@ -850,10 +803,10 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-all-contributors-cli@6.17.2:
-  version "6.17.2"
-  resolved "https://registry.yarnpkg.com/all-contributors-cli/-/all-contributors-cli-6.17.2.tgz#fb3461de56c378d1846e0b982ca0bd7ce4359c18"
-  integrity sha512-1ip57waUGz92HWbM5VgiGOjBz25fWXOtCRtCFbjCuuiCuiYbygnvcb9iFYiyNz28RlECg1VPXWrXOJABq+h+MQ==
+all-contributors-cli@6.17.4:
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/all-contributors-cli/-/all-contributors-cli-6.17.4.tgz#5d942479c8a1704b6ef772fd087c533dc90c326d"
+  integrity sha512-fv55BHQu1cna2/pJJdv/ULp1C7vfUMxnW8ZRm16RE0brTR3RmuEa4NPY180vHwFjGF5vBZdZsjX/+XxAyapazA==
   dependencies:
     "@babel/runtime" "^7.7.6"
     async "^3.0.1"
@@ -1048,14 +1001,14 @@ author-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
   integrity sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=
 
-auto@^9.53.1:
-  version "9.54.3"
-  resolved "https://registry.yarnpkg.com/auto/-/auto-9.54.3.tgz#64509bc2bc47794168f28c4bbebecc63808197f6"
-  integrity sha512-I+Mqi1Dz0nTA8NxdwdNlYcPP6NKIex0Lp6rdWvhmJF/+lyvHPVoXXrOdJRakxJOalR8eFjf2jU5IsPRP0DaUSg==
+auto@^9.54.6:
+  version "9.54.6"
+  resolved "https://registry.yarnpkg.com/auto/-/auto-9.54.6.tgz#afe26261b1906229d1a7e5e3a9c858962c68fa3a"
+  integrity sha512-7wHnxo1ruhXsgaz7YKMa8CmGe6v5MBz/DsToTrGou5/dwk3FHp3LI278JL6l0n0EGMcCUnXQ/hzVttAMyXXcmA==
   dependencies:
-    "@auto-it/core" "9.54.3"
-    "@auto-it/npm" "9.54.3"
-    "@auto-it/released" "9.54.3"
+    "@auto-it/core" "9.54.6"
+    "@auto-it/npm" "9.54.6"
+    "@auto-it/released" "9.54.6"
     await-to-js "^2.1.1"
     chalk "^4.0.0"
     command-line-application "^0.10.1"
@@ -2273,14 +2226,6 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
-
-gitlog@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/gitlog/-/gitlog-4.0.0.tgz#c4f440c822cc3fe1b32366d0662918871d3c7249"
-  integrity sha512-N6ZcvvbHsqhmM09wtzbL8v3FPwBK3EQ1xnv/2nj9JGH/YsYVn+ZkmMCxzkEjHnSFcpUk2HN2LBp76PGj3TkPag==
-  dependencies:
-    debug "^4.1.1"
-    tslib "^1.11.1"
 
 gitlog@^4.0.3:
   version "4.0.3"
@@ -3669,15 +3614,15 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@2.6.0, node-fetch@^2.3.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
 node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^2.3.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
# What Changed

# Why

Todo:
- [ ] Add Semantic Version Label 
- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.11.10-canary.20.283.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-plugin-no-explicit-type-exports@0.11.10-canary.20.283.0
  # or 
  yarn add eslint-plugin-no-explicit-type-exports@0.11.10-canary.20.283.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
