### PR TITLE
Add support for reexported types linting where `asType` syntax is used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 node_modules/
 coverage
 .env
+package-lock.json

--- a/src/rules/getTypeExports.ts
+++ b/src/rules/getTypeExports.ts
@@ -42,7 +42,11 @@ function parseTSTreeForExportedTypes(cacheKey: string, content: string): void {
           const { declaration, specifiers } = node;
 
           specifiers.forEach(specifier => {
-            cache.add(specifier.local.name);
+            if (specifier.local.name === specifier.exported.name) {
+              cache.add(specifier.local.name);
+            } else {
+              cache.add(`${specifier.local.name} as ${specifier.exported.name}`)
+            }
           });
 
           if (declaration && isType(declaration)) {
@@ -62,7 +66,7 @@ function parseTSTreeForExportedTypes(cacheKey: string, content: string): void {
       });
 
       cache.forEach(exp => {
-        if (!typeList.includes(exp)) {
+        if (!typeList.includes(exp.split(' as ')[0])) {
           cache.delete(exp);
         }
       });

--- a/src/rules/no-explicit-type-exports.ts
+++ b/src/rules/no-explicit-type-exports.ts
@@ -18,6 +18,10 @@ function isTypeStatement(
   );
 }
 
+function isExport(exported: TSESTree.ExportSpecifier | TSESTree.ImportClause): exported is TSESTree.ExportSpecifier {
+  return (<TSESTree.ExportSpecifier>exported).exported !== undefined;
+}
+
 export = {
   name: 'no-explicit-type-exports',
   meta: {
@@ -88,8 +92,16 @@ export = {
         node.specifiers.forEach(
           (specifier: TSESTree.ExportSpecifier | TSESTree.ImportClause) => {
             const { name } = specifier.local;
-            if (AllTypedImports.includes(name)) {
-              typedExports.push(name);
+            let exportedName = name;
+            if (isExport(specifier)) {
+              exportedName = specifier.exported.name;
+            }
+            if (AllTypedImports.includes(name) || AllTypedImports.includes(`${name} as ${exportedName}`)) {
+              if (name === exportedName) {
+                typedExports.push(name);
+              } else {
+                typedExports.push(`${name} as ${exportedName}`);
+              }
             } else {
               regularExports.push(name);
             }

--- a/tests/no-explicit-type-exports.test.ts
+++ b/tests/no-explicit-type-exports.test.ts
@@ -1,5 +1,6 @@
 import { RuleTester } from 'eslint';
-var path = require('path');
+import path from 'path';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const rule = require('../src/rules/no-explicit-type-exports');
 const parser = require.resolve('@typescript-eslint/parser');
 
@@ -24,6 +25,12 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule passes when a file imports and exports 'normal' variable
       filename: fileName,
       code: "import baz, {bar, foo} from './bar'; export {baz}",
+    },
+    {
+      // The rule passes when a file imports and exports a 'normal' variable
+      // And the variable is renamed using `asType` syntax
+      filename: fileName,
+      code: "import baz from './bar'; export { baz as IBaz }",
     },
     {
       // The rule passes when the file does not exist and the specifier is exported
@@ -54,6 +61,12 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule passes when export and import a type or interface on a single line
       filename: fileName,
       code: "export type { foo } from './bar';",
+    },
+    {
+      // The rule passes when export and import a type or interface on a single line
+      // And rename the export using `asType` syntax
+      filename: fileName,
+      code: "export type { foo as IFoo } from './bar';",
     },
     {
       // The rule passes when export and import a type or interface on a single line
@@ -132,6 +145,19 @@ ruleTester.run('no-explicit-type-exports', rule, {
         },
         {
           message: "Do not export 'baz' it is an imported type or interface.",
+        },
+      ],
+    },
+    {
+      // The rule fails when you export an imported type (single line type)
+      // And rename the type using `asType` syntax
+      filename: fileName,
+      code: "import type {baz} from './foo'; export {baz as IBaz};",
+      output: "import type {baz} from './foo'; export type { baz as IBaz };\n",
+      errors: [
+        {
+          message:
+            "Do not export 'baz as IBaz' it is an imported type or interface.",
         },
       ],
     },


### PR DESCRIPTION
# What Changed
I have added support for linting exports that use the `asType` syntax from the `@typescript/eslist-parser` AST.

I also added `package-lock.json` to the git ignore - figured if you're using yarn then you don't want this in there.

# Why
When I ran this on our code it stripped the `as x` from the code. For example if you did:
```
export { example as IExample } from './example'
```
It would lint and fix it to:
```
export type { example } from './example'
```
Where that should have been:
```
export type { example as IExample } from './example'
```

If `asType` syntax is not used then it defaults to the original name, as expected.

I've added two tests for this case.

Todo:
- [ ] Add Semantic Version Label 
- [x] Add tests
- [ ] Add docs
