### PR TITLE
Use path as the cache key for getTypeExports

### DIFF
--- a/src/fix.ts
+++ b/src/fix.ts
@@ -1,11 +1,14 @@
-import { RuleFixer } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
+import {
+  RuleFix,
+  RuleFixer,
+} from '@typescript-eslint/experimental-utils/dist/ts-eslint';
 import { TSESTree } from '@typescript-eslint/typescript-estree';
 
 const generateTypeFix = (
   type: 'import' | 'export',
   variables: string[],
   source: string,
-) => {
+): string => {
   const spacedSource = source ? ` ${source}` : '';
   return `${type} type { ${variables.join(',')} }${spacedSource};\n`;
 };
@@ -14,7 +17,7 @@ const generateNonTypeFix = (
   type: 'import' | 'export',
   variables: string[],
   source: string,
-) => {
+): string => {
   const spacedSource = source ? ` ${source}` : '';
   return `${type} { ${variables.join(',')} }${spacedSource};`;
 };
@@ -24,7 +27,7 @@ export const exportFixer = (
   typedExports: string[],
   regularExports: string[],
   fixer: RuleFixer,
-) => {
+): RuleFix | undefined => {
   try {
     const source =
       node.source && (node.source as any).raw
@@ -49,7 +52,7 @@ export const importFixer = (
   typedImports: string[],
   regularImports: string[],
   fixer: RuleFixer,
-) => {
+): RuleFix | undefined => {
   try {
     const source = 'from ' + node.source.raw;
     const importTypes = typedImports.length

--- a/src/rules/getTypeExports.ts
+++ b/src/rules/getTypeExports.ts
@@ -44,7 +44,9 @@ function parseTSTreeForExportedTypes(cacheKey: string, content: string): void {
             if (specifier.local.name === specifier.exported.name) {
               cache.add(specifier.local.name);
             } else {
-              cache.add(`${specifier.local.name} as ${specifier.exported.name}`)
+              cache.add(
+                `${specifier.local.name} as ${specifier.exported.name}`,
+              );
             }
           });
 

--- a/src/rules/getTypeExports.ts
+++ b/src/rules/getTypeExports.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import resolve from 'eslint-module-utils/resolve';
-import { hashObject } from 'eslint-module-utils/hash';
 import { parse } from '@typescript-eslint/parser';
 import { TSESTree } from '@typescript-eslint/typescript-estree';
 
@@ -93,7 +92,7 @@ function parseFileForTypedExports(
 
   try {
     const content = fs.readFileSync(path, { encoding: 'utf8' });
-    const cacheKey = hashObject(content).digest('hex');
+    const cacheKey = path;
     const cachedExports = fileCache.get(cacheKey);
 
     if (cachedExports) {

--- a/src/rules/no-explicit-type-exports.ts
+++ b/src/rules/no-explicit-type-exports.ts
@@ -18,8 +18,10 @@ function isTypeStatement(
   );
 }
 
-function isExport(exported: TSESTree.ExportSpecifier | TSESTree.ImportClause): exported is TSESTree.ExportSpecifier {
-  return (<TSESTree.ExportSpecifier>exported).exported !== undefined;
+function isExport(
+  exported: TSESTree.ExportSpecifier | TSESTree.ImportClause,
+): exported is TSESTree.ExportSpecifier {
+  return (exported as TSESTree.ExportSpecifier).exported !== undefined;
 }
 
 export = {
@@ -96,7 +98,10 @@ export = {
             if (isExport(specifier)) {
               exportedName = specifier.exported.name;
             }
-            if (AllTypedImports.includes(name) || AllTypedImports.includes(`${name} as ${exportedName}`)) {
+            if (
+              AllTypedImports.includes(name) ||
+              AllTypedImports.includes(`${name} as ${exportedName}`)
+            ) {
               if (name === exportedName) {
                 typedExports.push(name);
               } else {


### PR DESCRIPTION
On large monorepos, hashing the file contents was causing this plugin
to consume the majority of the time in any eslint run. I can see
hashing the file content being useful if you have multiple identical
copies of the same file in different places in the repo, but that should
be an extreme corner-case.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.11.11-canary.35.468.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-plugin-no-explicit-type-exports@0.11.11-canary.35.468.0
  # or 
  yarn add eslint-plugin-no-explicit-type-exports@0.11.11-canary.35.468.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
