### PR TITLE
Allow import type from file and export a type

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ import { aType, randomNumber, anInterface } from './foo';
 export * from './foo';
 ```
 
+```js
+import {aType} from './foo';
+
+export type {aType};
+```
+
 Invalid:
 
 ```js

--- a/src/rules/getExports.ts
+++ b/src/rules/getExports.ts
@@ -1,24 +1,35 @@
 import { TSESTree } from '@typescript-eslint/typescript-estree';
 
+interface ExportStatementAndName {
+  exp: string;
+  node: TSESTree.ExportDefaultDeclaration | TSESTree.ExportNamedDeclaration;
+}
+
 /**
  * A function that takes in an AST and returns a list of
  * the exported variables from ExportNamedDeclaration and
  * ExportDefaultDeclaration.
  */
-function getExports(ast: TSESTree.Program): Set<string> {
-  const exported = new Set<string>();
+function getExports(ast: TSESTree.Program): Set<ExportStatementAndName> {
+  const exported = new Set<ExportStatementAndName>();
 
   try {
     ast.body.forEach((node: TSESTree.Statement) => {
       if (node.type === 'ExportNamedDeclaration') {
         node.specifiers.forEach(specifier => {
-          exported.add(specifier.local.name);
+          exported.add({
+            node,
+            exp: specifier.local.name,
+          });
         });
       } else if (
         node.type === 'ExportDefaultDeclaration' &&
         node.declaration.type === 'Identifier'
       ) {
-        exported.add(node.declaration.name);
+        exported.add({
+          node,
+          exp: node.declaration.name,
+        });
       }
     });
   } catch (error) {

--- a/src/rules/no-explicit-type-exports.ts
+++ b/src/rules/no-explicit-type-exports.ts
@@ -10,11 +10,15 @@ function errorMessage(name: string): string {
 }
 
 function isTypeStatement(
-  node: TSESTree.ExportNamedDeclaration | TSESTree.ImportDeclaration,
+  node:
+    | TSESTree.ExportNamedDeclaration
+    | TSESTree.ImportDeclaration
+    | TSESTree.ExportDefaultDeclaration,
 ): boolean {
   return (
-    (node as TSESTree.ExportNamedDeclaration).exportKind === 'type' ||
-    (node as TSESTree.ImportDeclaration).importKind === 'type'
+    ((node as TSESTree.ExportNamedDeclaration).exportKind === 'type' ||
+      (node as TSESTree.ImportDeclaration).importKind === 'type') &&
+    node.type !== 'ExportDefaultDeclaration'
   );
 }
 
@@ -64,8 +68,12 @@ export = {
             },
           );
 
-          getExports(ast).forEach(exp => {
-            if (typedImports.includes(exp) && !isTypeStatement(node)) {
+          getExports(ast).forEach(({ exp, node: expNode }) => {
+            if (
+              typedImports.includes(exp) &&
+              !isTypeStatement(node) &&
+              !isTypeStatement(expNode)
+            ) {
               const isExport = type === 'ExportNamedDeclaration';
               context.report({
                 node,

--- a/tests/no-explicit-type-exports.test.ts
+++ b/tests/no-explicit-type-exports.test.ts
@@ -18,7 +18,6 @@ const ruleTester = new RuleTester({
   },
 });
 const fileName = path.join(process.cwd(), './tests/files', 'test.ts');
-
 ruleTester.run('no-explicit-type-exports', rule, {
   valid: [
     {
@@ -87,6 +86,11 @@ ruleTester.run('no-explicit-type-exports', rule, {
       // The rule passes when a file imports * from a file and exports as a single variable
       filename: fileName,
       code: "import type * as types from './bar'; export {types};",
+    },
+    {
+      // The rule passes when a file imports a type from a file and exports as a single type variable
+      filename: fileName,
+      code: "import {foo} from './bar'; export type {foo};",
     },
   ],
   invalid: [
@@ -300,17 +304,6 @@ ruleTester.run('no-explicit-type-exports', rule, {
         {
           message: "Do not export 'bar' it is an imported type or interface.",
         },
-        {
-          message: "Do not export 'x' it is an imported type or interface.",
-        },
-      ],
-    },
-    {
-      // The rule fails when export and import a type or interface on a single line
-      filename: fileName,
-      code: "import { x } from './oneLine'; export type { x };",
-      output: "import type { x } from './oneLine';\n export type { x };",
-      errors: [
         {
           message: "Do not export 'x' it is an imported type or interface.",
         },


### PR DESCRIPTION
# What Changed && Why
Fix for issue https://github.com/intuit/eslint-plugin-no-explicit-type-exports/issues/13 

Todo:
- [x] Add Semantic Version Label 
- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.12.1-canary.40.523.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-plugin-no-explicit-type-exports@0.12.1-canary.40.523.0
  # or 
  yarn add eslint-plugin-no-explicit-type-exports@0.12.1-canary.40.523.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
